### PR TITLE
Fix handling of null WCA IDs in newcomer pdf filtering

### DIFF
--- a/projects/newcomerpdfgen/newcomerpdfgen.js
+++ b/projects/newcomerpdfgen/newcomerpdfgen.js
@@ -37,7 +37,7 @@ function generatePDF() {
             header: true,
             complete: function(results) {
                 const data = results.data;
-                let newcomers = data.filter(row => row['WCA ID'] === ''); // Filter out the returning competitors
+                let newcomers = data.filter(row => row['WCA ID'] === '' || row['WCA ID'] === 'null'); // Filter out the returning competitors
                 newcomers = newcomers.filter(row => row['Name'] && row['Country'] && row['Birth Date'] && row['Gender']);
 
                 // Remove local names in parentheses from the 'Name' field and sort by name alphabetically


### PR DESCRIPTION
After the most recent update of the WCA registration system, exporting the registration list to a  CSV now sets a newcomer's WCA ID to `'null'` instead of `''`. This PR updates the filtering logic in the newcomer PDF generator to account for both `'null'` as well as empty strings when filtering for newcomers.